### PR TITLE
feat(TLS): Support certificate authority flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,18 +26,23 @@ jobs:
       - name: Install ShellCheck
         run: sudo apt-get install shellcheck
 
-      - name: Run ShellCheck
+      - name: Run ShellCheck entrypoint.sh
         run: shellcheck -x -s bash entrypoint.sh
 
+      - name: Run ShellCheck test script
+        run: shellcheck -x -s bash .github/workflows/scripts/*.sh
+
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         # This matrix allows us to test multiple bindplane versions.
         # When writing back to the repo, we write to directories based
         # on the bindplane version.
         bindplane_versions:
-          - 1.40.0
+          - 1.37.0
+          - 1.45.0
+          - latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,6 +55,19 @@ jobs:
       - name: Print Runner IP
         run: echo $MAIN_IP
 
+      - name: Generate TLS Certs
+        run: ./.github/workflows/scripts/tls.sh
+        env:
+          MAIN_IP: ${{ env.MAIN_IP }}
+
+      - name: Set CA certificate
+        run: |
+          {
+            echo 'TLS_CA_CERT<<EOF'
+            cat step/ca.crt
+            echo EOF
+          } >> "$GITHUB_ENV"
+
       - name: Pull BindPlane
         run: docker pull ghcr.io/observiq/bindplane-ee:${{ matrix.bindplane_versions }}
 
@@ -60,22 +78,27 @@ jobs:
             --name bindplane \
             -e BINDPLANE_USERNAME=admin \
             -e BINDPLANE_PASSWORD=admin \
-            -e BINDPLANE_REMOTE_URL=http://${MAIN_IP}:3001 \
+            -e BINDPLANE_REMOTE_URL=https://${MAIN_IP}:3001 \
             -e BINDPLANE_SESSION_SECRET=2c23c9d3-850f-4062-a5c8-3f9b814ae144 \
             -e BINDPLANE_SECRET_KEY=8a5353f7-bbf4-4eea-846d-a6d54296b781 \
             -e BINDPLANE_LOG_OUTPUT=stdout \
             -e BINDPLANE_ACCEPT_EULA=true \
+            -e BINDPLANE_TLS_CERT=/bindplane.crt \
+            -e BINDPLANE_TLS_KEY=/bindplane.key \
             -p 3001:3001 \
+            -v $(pwd)/step/bindplane.crt:/bindplane.crt \
+            -v $(pwd)/step/bindplane.key:/bindplane.key \
+            -v $(pwd)/step/ca.crt:/ca.crt \
             ghcr.io/observiq/bindplane-ee:${{ matrix.bindplane_versions }}
 
       - name: Wait for BindPlane
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 1
-          polling_interval_seconds: 5
-          max_attempts: 10
+          polling_interval_seconds: 2
+          max_attempts: 3
           shell: bash
-          command: docker exec bindplane /bindplane get agent
+          command: docker exec bindplane /bindplane get agent --tls-ca /ca.crt
 
       - name: Run BindPlane Action
         # This should be replaced with a release action.
@@ -103,12 +126,15 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           enable_otel_config_write_back: true
           enable_auto_rollout: true
+          # Generally this would come from a secret, but the certificate
+          # was created in this workflow.
+          tls_ca_cert: ${{ env.TLS_CA_CERT }}
 
       - name: Get Resources
         if: always()
         run: |
-          docker exec bindplane /bindplane get destinations
-          docker exec bindplane /bindplane get configurations
+          docker exec bindplane /bindplane get destinations --tls-ca /ca.crt
+          docker exec bindplane /bindplane get configurations --tls-ca /ca.crt
 
       - name: Debug Container Logs
         if: always()

--- a/.github/workflows/scripts/tls.sh
+++ b/.github/workflows/scripts/tls.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -z "$MAIN_IP" ]; then
+    echo "MAIN_IP is not set"
+    exit 1
+fi
+
+curl -L -s -o step.tar.gz \
+    https://dl.step.sm/gh-release/cli/gh-release-header/v0.22.0/step_linux_0.22.0_amd64.tar.gz
+tar -xzf step.tar.gz
+mv step_0.22.0/bin/step /usr/local/bin/step
+rm -f step.tar.gz
+rm -rf step_0.22.0
+
+mkdir step/
+chmod -R 0755 step/
+
+step certificate create \
+    ca.internal \
+    step/ca.crt step/ca.key \
+    --profile root-ca \
+    --no-password \
+    --insecure \
+    --not-after=8760h
+
+step certificate create \
+    bindplane.internal \
+    step/bindplane.crt step/bindplane.key \
+    --san "${MAIN_IP}" \
+    --profile leaf \
+    --not-after 2160h \
+    --no-password \
+    --insecure \
+    --ca step/ca.crt \
+    --ca-key step/ca.key
+
+chmod 0644 step/*

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ server. It also supports exporting the OpenTelemetry configurations back to the 
 | configuration_output_branch   |            | The branch to write the OTEL configuration resources to. If unset, target_branch will be used. |
 | token                         |            | The Github token that will be used to write to the repo. Usually secrets.GITHUB_TOKEN is sufficient. Requires the `contents.write` permission. |
 | enable_auto_rollout           | `false`    | When enabled, the action will trigger a rollout for any configuration that has been updated. |
+| tls_ca_cert                   |            | The contents of a TLS certificate authority, usually from a secret. See the [TLS](#tls) section. |
 
 ## Usage
 
@@ -94,4 +95,25 @@ otel
 ├── k8s-cluster.yaml
 ├── k8s-gateway.yaml
 └── k8s-node.yaml
+```
+
+### TLS
+
+TLS can be configured by setting `tls_ca_cert` to a secret that contains
+your TLS certificate authority. This should be the contents of an x509 PEM
+certificate, not a file path.
+
+This example shows `tls_ca_cert` being set using a secret, and `bindplane_remote_url`
+using a TLS endpoint (`https`).
+
+```yaml
+- uses: observIQ/bindplane-op-action@main
+  with:
+    tls_ca_cert: ${{ secrets.TLS_CA }}
+    bindplane_remote_url: https://bindplane.mycorp.net
+    bindplane_username: ${{ secrets.BINDPLANE_USERNAME }}
+    bindplane_password: ${{ secrets.BINDPLANE_PASSWORD }}
+    target_branch: main
+    destination_path: destination.yaml
+    configuration_path: configuration.yaml     
 ```

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,8 @@ inputs:
   enable_auto_rollout:
     description: 'When enabled, the action will trigger a rollout for all configurations that have been updated'
     default: false
+  tls_ca_cert:
+    description: 'The CA certificate to use when connecting to BindPlane OP'
 
 runs:
   using: 'docker'
@@ -49,3 +51,4 @@ runs:
     - ${{ inputs.token }}
     - ${{ inputs.enable_auto_rollout }}
     - ${{ inputs.configuration_output_branch }}
+    - ${{ inputs.tls_ca_cert }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ configuration_output_dir=${9}
 token=${10}
 enable_auto_rollout=${11}
 configuration_output_branch=${12}
+tls_ca_cert=${13}
 
 # This branch name will be compared to target_branch to determine if the action
 # should apply or write back configurations.
@@ -24,7 +25,7 @@ echo "Current branch is $BRANCH_NAME"
 install_bindplane_cli() {
   curl -Ls \
     -o bindplane.zip \
-    https://storage.googleapis.com/bindplane-op-releases/bindplane/latest/bindplane-ee-linux-amd64.zip
+    https://storage.googleapis.com/bindplane-op-releases/bindplane/1.46.0/bindplane-ee-linux-amd64.zip
 
   mkdir -p ~/bin
   export PATH=$PATH:~/bin
@@ -66,6 +67,12 @@ validate() {
     exit 1
   elif [ -n "$bindplane_api_key" ]; then
     profile_args="$profile_args --api-key $bindplane_api_key"
+  fi
+
+  if [ -n "$tls_ca_cert" ]; then
+    echo "tls_ca_cert is set, adding to profile."
+    echo "$tls_ca_cert" > ca.pem
+    profile_args="$profile_args --tls-ca ca.pem"
   fi
 
   # configuration_output_dir, target_branch, and token are only required


### PR DESCRIPTION
Added new `tls_ca_cert` option to the action. See the README change for example usage.

I updated CI to generate certificates on each run. The CI action will use the new TLS option to interface with BindPlane. This proves that it is working. Without the TLS option, I was getting errors due to certificate verification failure.
