### PR TITLE
feat(apply): Support sources and processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ server. It also supports exporting the OpenTelemetry configurations back to the 
 | bindplane_username            |            | Username used to authenticate to BindPlane. Not required if API key is set. |
 | bindplane_password            |            | Password used to authenticate to BindPlane.
 | target_branch                 | required   | The branch that the action will use when applying resources to bindplane or when writing otel configs back to the repo. |
-| destination_path              |            | Path to the file which contains the BindPlane destination resources |
-| configuration_path            |            | Path to the file which contains the BindPlane configuration resources |
+| destination_path              | required   | Path to the file which contains the BindPlane destination resources |
+| source_path                   |            | Path to the file which contains the BindPlane source resources |
+| processor_path                |            | Path to the file which contains the BindPlane processor resources |
+| configuration_path            | required   | Path to the file which contains the BindPlane configuration resources |
 | enable_otel_config_write_back | `false`    | Whether or not the action should write the raw OpenTelemetry configurations back to the repository. | 
 | configuration_output_dir      |            | When write back is enabled, this is the path that will be written to. |
 | configuration_output_branch   |            | The branch to write the OTEL configuration resources to. If unset, target_branch will be used. |
@@ -32,6 +34,8 @@ the `bindplane get` commands with the `--export` flag.
 
 ```bash
 bindplane get destination -o yaml --export > destination.yaml
+bindplane get source -o yaml --export > source.yaml
+bindplane get processor -o yaml --export > processor.yaml
 bindplane get configuration -o yaml --export > configuration.yaml
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: 'Resource apply and OTEL config write back will only happen when this branch is the current branch of the action'
   destination_path:
     description: 'Path to the file which contains the BindPlane destination resources'
+  source_path:
+    description: 'Path to the file which contains the BindPlane source resources'
+  processor_path:
+    description: 'Path to the file which contains the BindPlane processor resources'
   configuration_path:
     description: 'Path to the file which contains the BindPlane configuration resources'
   enable_otel_config_write_back:
@@ -52,3 +56,5 @@ runs:
     - ${{ inputs.enable_auto_rollout }}
     - ${{ inputs.configuration_output_branch }}
     - ${{ inputs.tls_ca_cert }}
+    - ${{ inputs.source_path }}
+    - ${{ inputs.processor_path }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,8 @@ token=${10}
 enable_auto_rollout=${11}
 configuration_output_branch=${12}
 tls_ca_cert=${13}
+source_path=${14}
+processor_path=${15}
 
 # This branch name will be compared to target_branch to determine if the action
 # should apply or write back configurations.
@@ -104,6 +106,16 @@ validate() {
     fi
   fi
 
+  if [ -z "$configuration_path" ]; then
+    echo "configuration_path is required."
+    exit 1
+  fi
+
+  if [ -z "$destination_path" ]; then
+    echo "destination_path is required."
+    exit 1
+  fi
+
   eval bindplane profile set "action" "$profile_args"
   bindplane profile use "action"
 }
@@ -170,6 +182,16 @@ main() {
 
   echo "Applying destination path: $destination_path"
   bindplane apply "$destination_path"
+
+  if [ -n "$source_path" ]; then
+    echo "Applying source path: $source_path"
+    bindplane apply "$source_path"
+  fi
+
+  if [ -n "$processor_path" ]; then
+    echo "Applying processor path: $processor_path"
+    bindplane apply "$processor_path"
+  fi
 
   echo "Applying configuration path: $configuration_path"
   bindplane apply "$configuration_path" > configuration.out


### PR DESCRIPTION
BindPlane [v1.47.0](https://observiq.com/docs/release-notes) introduced the resource library. This allows users to save sources and processors, to be shared by multiple configurations.

This PR allows users to apply sources and processors.

Changes
- Made configuration_path and destination_path required options
  - If they were not set, it would result in an action error
- Added `source_path` and `processor_path` options
  - These are optional, with runtime checks to see if they are set before applying

## Testing

I added sources and processors to my test environment resource library.

I updated my example repo here: https://github.com/jsirianni/bindplane-gitops-example/blob/main/.github/workflows/bindplane.yml

It includes the new source and processor options as well as the updated configurations that point to the library resources instead of having them configured inline.

After adding the library resources, I confirmed that updates to sources were automatically applied to configurations that used them, and the automatic rollout feature was triggered.

![Screenshot from 2024-03-13 11-28-00](https://github.com/observIQ/bindplane-op-action/assets/23043836/78c35af8-5be6-4bfb-9d91-ebbec5f629f4)

https://github.com/jsirianni/bindplane-gitops-example/actions/runs/8267177240/job/22616932539
