### PR TITLE
fix: Use eval to expand file path globbing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -183,20 +183,20 @@ main() {
   echo "Applying resources."
 
   echo "Applying destination path: $destination_path"
-  bindplane apply "$destination_path"
+  eval bindplane apply "$destination_path"
 
   if [ -n "$source_path" ]; then
     echo "Applying source path: $source_path"
-    bindplane apply "$source_path"
+    eval bindplane apply "$source_path"
   fi
 
   if [ -n "$processor_path" ]; then
     echo "Applying processor path: $processor_path"
-    bindplane apply "$processor_path"
+    eval bindplane apply "$processor_path"
   fi
 
   echo "Applying configuration path: $configuration_path"
-  bindplane apply "$configuration_path" > configuration.out
+  eval bindplane apply "$configuration_path" > configuration.out
   cat configuration.out
 
   # When auto rollout is enabled


### PR DESCRIPTION
Prefix `bindplane apply` with `eval` to expand paths that use globbing. This allows a user to specify a directory like `configurations/*.yaml` instead of a single file.

You can see it working in my test repo. Glob paths failed until I switched to this branch.

Before (failure): https://github.com/jsirianni/bindplane-gitops-example/actions/runs/8396459780
After (pass): https://github.com/jsirianni/bindplane-gitops-example/actions/runs/8396531035/job/22998098348