### PR TITLE
feat: github_host option defaulting to github.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ BindPlane requires a license. You can request a free license [here](https://obse
 | enable_otel_config_write_back | `false`    | Whether or not the action should write the raw OpenTelemetry configurations back to the repository. | 
 | configuration_output_dir      |            | When write back is enabled, this is the path that will be written to. |
 | configuration_output_branch   |            | The branch to write the OTEL configuration resources to. If unset, target_branch will be used. |
-| token                         |            | The Github token that will be used to write to the repo. Usually secrets.GITHUB_TOKEN is sufficient. Requires the `contents.write` permission. |
+| token                         |            | The Github token that will be used to write to the repo. Usually secrets.GITHUB_TOKEN is sufficient. Requires the `contents.write` permission. Alternatively, you can set `github_url`, which should contain your access token. |
 | enable_auto_rollout           | `false`    | When enabled, the action will trigger a rollout for any configuration that has been updated. |
 | tls_ca_cert                   |            | The contents of a TLS certificate authority, usually from a secret. See the [TLS](#tls) section. |
-| github_host                | `github.com` | The hostname to use when cloning the repository. |
+| github_url                    |            | Optional URL to use when closing the repository. Should be of the form `"https://{GITHUB_ACTOR}:{TOKEN}@{GITHUB_HOST}/{GITHUB_REPOSITORY}.git` |
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ BindPlane requires a license. You can request a free license [here](https://obse
 | token                         |            | The Github token that will be used to write to the repo. Usually secrets.GITHUB_TOKEN is sufficient. Requires the `contents.write` permission. |
 | enable_auto_rollout           | `false`    | When enabled, the action will trigger a rollout for any configuration that has been updated. |
 | tls_ca_cert                   |            | The contents of a TLS certificate authority, usually from a secret. See the [TLS](#tls) section. |
+| github_host                | `github.com` | The hostname to use when cloning the repository. |
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ BindPlane requires a license. You can request a free license [here](https://obse
 | token                         |            | The Github token that will be used to write to the repo. Usually secrets.GITHUB_TOKEN is sufficient. Requires the `contents.write` permission. Alternatively, you can set `github_url`, which should contain your access token. |
 | enable_auto_rollout           | `false`    | When enabled, the action will trigger a rollout for any configuration that has been updated. |
 | tls_ca_cert                   |            | The contents of a TLS certificate authority, usually from a secret. See the [TLS](#tls) section. |
-| github_url                    |            | Optional URL to use when closing the repository. Should be of the form `"https://{GITHUB_ACTOR}:{TOKEN}@{GITHUB_HOST}/{GITHUB_REPOSITORY}.git` |
+| github_url                    |            | Optional URL to use when closing the repository. Should be of the form `"https://{GITHUB_ACTOR}:{TOKEN}@{GITHUB_HOST}/{GITHUB_REPOSITORY}.git`. When set, `token` will not be used. |
 
 
 ## Usage

--- a/action.yml
+++ b/action.yml
@@ -36,9 +36,8 @@ inputs:
     default: false
   tls_ca_cert:
     description: 'The CA certificate to use when connecting to BindPlane OP'
-  github_host:
-    description: 'The GitHub host to use when connecting to GitHub'
-    default: 'github.com'
+  github_url:
+    description: 'The GitHub URL to use when connecting to GitHub'
 
 runs:
   using: 'docker'
@@ -61,4 +60,4 @@ runs:
     - ${{ inputs.tls_ca_cert }}
     - ${{ inputs.source_path }}
     - ${{ inputs.processor_path }}
-    - ${{ inputs.github_host }}
+    - ${{ inputs.github_url }}

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
     default: false
   tls_ca_cert:
     description: 'The CA certificate to use when connecting to BindPlane OP'
+  github_host:
+    description: 'The GitHub host to use when connecting to GitHub'
+    default: 'github.com'
 
 runs:
   using: 'docker'
@@ -58,3 +61,4 @@ runs:
     - ${{ inputs.tls_ca_cert }}
     - ${{ inputs.source_path }}
     - ${{ inputs.processor_path }}
+    - ${{ inputs.github_host }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,7 @@ configuration_output_branch=${12}
 tls_ca_cert=${13}
 source_path=${14}
 processor_path=${15}
+github_host=${16}
 
 # This branch name will be compared to target_branch to determine if the action
 # should apply or write back configurations.
@@ -132,7 +133,7 @@ write_back() {
   git clone \
     --depth 1 \
     --branch "$write_back_branch" \
-    "https://${GITHUB_ACTOR}:${token}@github.com/${GITHUB_REPOSITORY}.git" \
+    "https://${GITHUB_ACTOR}:${token}@${github_host}/${GITHUB_REPOSITORY}.git" \
     ../out_repo
 
   cd "../out_repo"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -142,7 +142,7 @@ write_back() {
   git clone \
     --depth 1 \
     --branch "$write_back_branch" \
-    "https://${GITHUB_ACTOR}:${token}@${github_host}/${GITHUB_REPOSITORY}.git" \
+    "${github_url}" \
     ../out_repo
 
   cd "../out_repo"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ configuration_output_branch=${12}
 tls_ca_cert=${13}
 source_path=${14}
 processor_path=${15}
-github_host=${16}
+github_url=${16}
 
 # This branch name will be compared to target_branch to determine if the action
 # should apply or write back configurations.
@@ -90,9 +90,12 @@ validate() {
       exit 1
     fi
 
+    # A token or github_url are required when target_branch is set.
     if [ -z "$token" ]; then
-      echo "token is required when target_branch is set."
-      exit 1
+      if [ -z "$github_url" ]; then
+        echo "token or github_url are required when target_branch is set."
+        exit 1
+      fi
     fi
 
     # GITHUB_ACTOR and GITHUB_REPOSITORY are set by the github actions runtime
@@ -127,6 +130,12 @@ write_back() {
   # The configuration_output_branch is optional. If not set, the
   # write back branch will be the same as the target branch.
   write_back_branch=${configuration_output_branch:-$target_branch}
+
+  # if the github_url is set, use it, otherwise default to github.com
+  github_url=${github_url:-github.com}
+  if [ -z "$github_host" ]; then
+    github_url="https://${GITHUB_ACTOR}:${token}@github.com/${GITHUB_REPOSITORY}.git"
+  fi
 
   # Clone the repo on the current branch
   # and use depth 1 to avoid cloning the entire history.


### PR DESCRIPTION
Github Enterprise users may have an alternative URL that they connect to when cloning repos. This URL will contain the required authentication user / token.

Failures look like this when set to a bad host: https://github.com/jsirianni/bindplane-gitops-example/actions/runs/8634598214/job/23670409872
```
remote: Invalid username or password.
fatal: Authentication failed for 'https://github.com/jsirianni/bindplane-gitops-example.git/'
```



When `token` and `github_url` are unset, write back correctly fails with: https://github.com/jsirianni/bindplane-gitops-example/actions/runs/8634613162/job/23670463116
```
Validating options and configuring client profile.
token or github_url are required when target_branch is set.
```


Leaving the option unset defaults to using github_token and passes: https://github.com/jsirianni/bindplane-gitops-example/actions/runs/8634561203/job/23670291925

![Screenshot from 2024-04-10 12-21-52](https://github.com/observIQ/bindplane-op-action/assets/23043836/90eaf206-13a9-4a16-9cf8-163716977fe5)
