### PR TITLE
Use full path to TLS CA

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,7 +80,7 @@ validate() {
     ca_full_path=$(pwd)/ca.pem
     # TODO(jsirianni): Switch to flag param when fixed
     export BINDPLANE_TLS_CA="$ca_full_path"
-    # profile_args="$profile_args --tls-ca ca_full_path"
+    # profile_args="$profile_args --tls-ca $ca_full_path"
   fi
 
   # configuration_output_dir, target_branch, and token are only required

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -77,9 +77,10 @@ validate() {
   if [ -n "$tls_ca_cert" ]; then
     echo "tls_ca_cert is set, adding to profile."
     echo "$tls_ca_cert" > ca.pem
+    ca_full_path=$(pwd)/ca.pem
     # TODO(jsirianni): Switch to flag param when fixed
-    export BINDPLANE_TLS_CA=ca.pem
-    # profile_args="$profile_args --tls-ca ca.pem"
+    export BINDPLANE_TLS_CA="$ca_full_path"
+    # profile_args="$profile_args --tls-ca ca_full_path"
   fi
 
   # configuration_output_dir, target_branch, and token are only required


### PR DESCRIPTION
This resolves an issue where the CLI cannot read the certificate because the working directory has changed.