### PR TITLE
fix(regression): Support input path globbing in Go re-write

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -495,11 +495,12 @@ func (a *Action) WriteBack() error {
 // function should not be passed multiple files with differing resource
 // types such as Destinations and Configurations.
 func decodeAnyResourceFile(path string) ([]*model.AnyResource, error) {
+	// Glob will return nil matches if there are IO errors. Glob only returns
+	// an error if an invalid pattern is given.
 	matches, err := filepath.Glob(path) // #nosec G304 user defined filepath
 	if err != nil {
 		return nil, fmt.Errorf("glob path %s: %w", path, err)
 	}
-
 	if matches == nil {
 		return nil, fmt.Errorf("no matching files found when globbing %s", path)
 	}

--- a/action/action.go
+++ b/action/action.go
@@ -500,6 +500,10 @@ func decodeAnyResourceFile(path string) ([]*model.AnyResource, error) {
 		return nil, fmt.Errorf("glob path %s: %w", path, err)
 	}
 
+	if matches == nil {
+		return nil, fmt.Errorf("no matching files found when globbing %s", path)
+	}
+
 	resources := []*model.AnyResource{}
 
 	for _, match := range matches {

--- a/action/action.go
+++ b/action/action.go
@@ -241,7 +241,7 @@ func (a *Action) Apply() error {
 	}
 
 	if a.sourcePath != "" {
-		a.Logger.Info("Applying resources", zap.String("Kind", string(model.KindSource)), zap.String("file", a.destinationPath))
+		a.Logger.Info("Applying resources", zap.String("Kind", string(model.KindSource)), zap.String("file", a.sourcePath))
 		err := a.apply(a.sourcePath)
 		if err != nil {
 			return fmt.Errorf("sources: %w", err)
@@ -251,7 +251,7 @@ func (a *Action) Apply() error {
 	}
 
 	if a.processorPath != "" {
-		a.Logger.Info("Applying resources", zap.String("Kind", string(model.KindProcessor)), zap.String("file", a.destinationPath))
+		a.Logger.Info("Applying resources", zap.String("Kind", string(model.KindProcessor)), zap.String("file", a.processorPath))
 		err := a.apply(a.processorPath)
 		if err != nil {
 			return fmt.Errorf("processors: %w", err)
@@ -261,7 +261,7 @@ func (a *Action) Apply() error {
 	}
 
 	if a.configurationPath != "" {
-		a.Logger.Info("Applying resources", zap.String("Kind", string(model.KindConfiguration)), zap.String("file", a.destinationPath))
+		a.Logger.Info("Applying resources", zap.String("Kind", string(model.KindConfiguration)), zap.String("file", a.configurationPath))
 		err := a.apply(a.configurationPath)
 		if err != nil {
 			return fmt.Errorf("configuration: %w", err)

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -527,7 +527,7 @@ func TestDecodeAnyResourceFileGlob(t *testing.T) {
 	resources, err := decodeAnyResourceFile("testdata/*.yaml")
 	require.NoError(t, err)
 	require.NotNil(t, resources)
-	require.Len(t, resources, 3)
+	require.Len(t, resources, 4)
 
 	for _, r := range resources {
 		require.Equal(t, "bindplane.observiq.com/v1", r.APIVersion)

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -546,3 +546,27 @@ func TestDecodeAnyResourceFileGlob(t *testing.T) {
 		require.Contains(t, platforms, v, "Expected platform label to be one of %v, got %s", platforms, v)
 	}
 }
+
+func TestDecodeAnyResourceFileGlobMatchOne(t *testing.T) {
+	resources, err := decodeAnyResourceFile("testdata/config*.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, resources)
+	require.Len(t, resources, 3)
+
+	for _, r := range resources {
+		require.Equal(t, "bindplane.observiq.com/v1", r.APIVersion)
+		require.Equal(t, "Configuration", r.Kind)
+		require.NotEmpty(t, r.Metadata.ID)
+		require.NotEmpty(t, r.Metadata.Name)
+		require.Len(t, r.Metadata.Labels, 1, "Expected 1 label")
+		platforms := []string{
+			"kubernetes-gateway",
+			"kubernetes-daemonset",
+			"kubernetes-deployment",
+		}
+		key := "platform"
+		v, ok := r.Metadata.Labels[key]
+		require.True(t, ok, "Expected label %s", key)
+		require.Contains(t, platforms, v, "Expected platform label to be one of %v, got %s", platforms, v)
+	}
+}

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -522,3 +522,27 @@ func TestDecodeAnyResourceFile(t *testing.T) {
 		require.Contains(t, platforms, v, "Expected platform label to be one of %v, got %s", platforms, v)
 	}
 }
+
+func TestDecodeAnyResourceFileGlob(t *testing.T) {
+	resources, err := decodeAnyResourceFile("testdata/*.yaml")
+	require.NoError(t, err)
+	require.NotNil(t, resources)
+	require.Len(t, resources, 3)
+
+	for _, r := range resources {
+		require.Equal(t, "bindplane.observiq.com/v1", r.APIVersion)
+		require.Equal(t, "Configuration", r.Kind)
+		require.NotEmpty(t, r.Metadata.ID)
+		require.NotEmpty(t, r.Metadata.Name)
+		require.Len(t, r.Metadata.Labels, 1, "Expected 1 label")
+		platforms := []string{
+			"kubernetes-gateway",
+			"kubernetes-daemonset",
+			"kubernetes-deployment",
+		}
+		key := "platform"
+		v, ok := r.Metadata.Labels[key]
+		require.True(t, ok, "Expected label %s", key)
+		require.Contains(t, platforms, v, "Expected platform label to be one of %v, got %s", platforms, v)
+	}
+}

--- a/action/testdata/cluster.yaml
+++ b/action/testdata/cluster.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: bindplane.observiq.com/v1
+kind: Configuration
+metadata:
+    id: k8s-cluster2
+    name: k8s-cluster2
+    labels:
+        platform: kubernetes-deployment
+spec:
+    contentType: ""
+    measurementInterval: ""
+    sources:
+        - id: 01HMS8GVNVFVD5TSWTKSJR1RY5
+          type: k8s_cluster
+          parameters:
+            - name: cluster_name
+              value: minikube
+            - name: node_conditions_to_report
+              value:
+                - Ready
+                - DiskPressure
+                - MemoryPressure
+                - PIDPressure
+                - NetworkUnavailable
+            - name: allocatable_types_to_report
+              value:
+                - cpu
+                - memory
+                - ephemeral-storage
+                - storage
+            - name: collection_interval
+              value: 60
+            - name: distribution
+              value: kubernetes
+        - id: 01HMS8GVNVFVD5TSWTKVNZS2JC
+          displayName: Production events
+          type: k8s_events
+          parameters:
+            - name: cluster_name
+              value: minikube
+            - name: namespaces
+              value:
+                - kube-system
+                - production
+    destinations:
+        - id: 01HMS8GVNVFVD5TSWTKZZNHB8R
+          name: bindplane-gateway-agent
+    selector:
+        matchLabels:
+            configuration: k8s-cluster2

--- a/cmd/action/validate.go
+++ b/cmd/action/validate.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/observiq/bindplane-op-action/action"
+	"github.com/observiq/bindplane-op-action/internal/client/model"
 )
 
 func validate() error {
@@ -124,11 +125,11 @@ func validateActionsEnvironment() error {
 }
 
 func validateFilePaths() error {
-	files := map[string]string{
-		KindDestination:   destination_path,
-		KindSource:        source_path,
-		KindProcessor:     processor_path,
-		KindConfiguration: configuration_path,
+	files := map[model.Kind]string{
+		model.KindDestination:   destination_path,
+		model.KindSource:        source_path,
+		model.KindProcessor:     processor_path,
+		model.KindConfiguration: configuration_path,
 	}
 
 	for kind, path := range files {
@@ -136,7 +137,7 @@ func validateFilePaths() error {
 			continue
 		}
 
-		matches, err := filepath.Glob
+		matches, err := filepath.Glob(path)
 		if err != nil {
 			return fmt.Errorf("glob %s path %s: %w", kind, path, err)
 		}

--- a/cmd/action/validate.go
+++ b/cmd/action/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 
 	"github.com/observiq/bindplane-op-action/action"
 )
@@ -123,27 +124,25 @@ func validateActionsEnvironment() error {
 }
 
 func validateFilePaths() error {
-	if destination_path != "" {
-		if _, err := os.Stat(destination_path); os.IsNotExist(err) {
-			return fmt.Errorf("destination_path does not exist: %s", destination_path)
-		}
+	files := map[string]string{
+		KindDestination:   destination_path,
+		KindSource:        source_path,
+		KindProcessor:     processor_path,
+		KindConfiguration: configuration_path,
 	}
 
-	if source_path != "" {
-		if _, err := os.Stat(source_path); os.IsNotExist(err) {
-			return fmt.Errorf("source_path does not exist: %s", source_path)
+	for kind, path := range files {
+		if path == "" {
+			continue
 		}
-	}
 
-	if processor_path != "" {
-		if _, err := os.Stat(processor_path); os.IsNotExist(err) {
-			return fmt.Errorf("processor_path does not exist: %s", processor_path)
+		matches, err := filepath.Glob
+		if err != nil {
+			return fmt.Errorf("glob %s path %s: %w", kind, path, err)
 		}
-	}
 
-	if configuration_path != "" {
-		if _, err := os.Stat(configuration_path); os.IsNotExist(err) {
-			return fmt.Errorf("configuration_path does not exist: %s", configuration_path)
+		if matches == nil {
+			return fmt.Errorf("%s path %s does not exist or did not match any files with globbing", kind, path)
 		}
 	}
 


### PR DESCRIPTION
The input file path is supported but is not working after the Go re-write v1.4.0.

Tests were added to confirm the failure, they pass now.
- Test multiple files with glob
- Test single file with glob

Re-wrote `validateFilePaths` and updated `decodeAnyResourceFile` functions to support glob matches before reading resources. The action is validation-heavy, we have two layers of protection here.

`filepath.Glob` can return nil matches and a nil error, so we always need to check if the matches are nil. If it is, it could indicate an io error in rare cases. Glob will only return an error if the match pattern is invalid. https://pkg.go.dev/path/filepath#Glob

This change is backward compatible.

### Testing

My test repo is passing, using globbing for the configuration path. https://github.com/jsirianni/bindplane-op-action-test/actions/runs/9207348741/job/25328061583

```json
{"level":"info","time":"2024-05-23T12:05:20.990Z","msg":"Resource applied","name":"k8s-cluster","id":"k8s-cluster","kind":"Configuration","status":"unchanged"}
{"level":"debug","time":"2024-05-23T12:05:20.990Z","msg":"Configuration resource added to state","name":"k8s-cluster"}
{"level":"info","time":"2024-05-23T12:05:20.990Z","msg":"Applied resource","name":"k8s-cluster","status":"unchanged"}
{"level":"info","time":"2024-05-23T12:05:20.990Z","msg":"Resource applied","name":"k8s-gateway","id":"k8s-gateway","kind":"Configuration","status":"unchanged"}
{"level":"debug","time":"2024-05-23T12:05:20.990Z","msg":"Configuration resource added to state","name":"k8s-gateway"}
{"level":"info","time":"2024-05-23T12:05:20.990Z","msg":"Applied resource","name":"k8s-gateway","status":"unchanged"}
{"level":"info","time":"2024-05-23T12:05:20.990Z","msg":"Resource applied","name":"k8s-node","id":"k8s-node","kind":"Configuration","status":"unchanged"}
{"level":"debug","time":"2024-05-23T12:05:20.990Z","msg":"Configuration resource added to state","name":"k8s-node"}
{"level":"info","time":"2024-05-23T12:05:20.990Z","msg":"Applied resource","name":"k8s-node","status":"unchanged"}
{"level":"info","time":"2024-05-23T12:05:21.174Z","msg":"No pending rollout","name":"k8s-cluster"}
{"level":"info","time":"2024-05-23T12:05:21.210Z","msg":"No pending rollout","name":"k8s-gateway"}
{"level":"info","time":"2024-05-23T12:05:21.245Z","msg":"No pending rollout","name":"k8s-node"}
```