### PR TITLE
feat: Progressive rollouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,30 @@ using a TLS endpoint (`https`).
     destination_path: destination.yaml
     configuration_path: configuration.yaml     
 ```
+
+### Progressive Rollouts
+
+The action can be used to progress a rollout ad-hoc, without modifying
+configurations.
+
+To trigger a rollout progression, format your commit message with `progress rollout <name>`.
+
+Example:
+
+```bash
+git commit --allow-empty -m "progress rollout my-config"
+```
+
+The commit message must match this regular expression:
+
+```
+progress rollout (\S+)$
+```
+
+Therefore the commit message can contain additional details, such as:
+
+```bash
+git commit \
+  --allow-empty \
+  -m "Trigger rollout for dev: progress rollout dev-config"
+```

--- a/action/action.go
+++ b/action/action.go
@@ -224,6 +224,15 @@ func (a *Action) Run() error {
 	return nil
 }
 
+// RunRollout progresses a rollout for a configuration
+func (a *Action) RunRollout(config string) error {
+	if err := a.client.StartRollout(config); err != nil {
+		return fmt.Errorf("start rollout: %w", err)
+	}
+
+	return nil
+}
+
 // Apply applies destinations, sources, processors, and configurations
 // in that order. It is important to apply destinations first, followed
 // by resource library sources and processors. Configurations should be

--- a/action/action.go
+++ b/action/action.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -378,10 +377,6 @@ func (a *Action) WriteBack() error {
 			a.githubToken,
 			githubRepo,
 		)
-	}
-	// TODO(jsirianni) this is just for quick testing, remove before merge
-	if _, err := url.Parse(cloneURL); err != nil {
-		panic("invalid github url")
 	}
 
 	a.Logger.Info(

--- a/cmd/action/main_test.go
+++ b/cmd/action/main_test.go
@@ -49,6 +49,30 @@ func Test_extractName(t *testing.T) {
 			found:    false,
 			expected: "",
 		},
+		{
+			name:     "Config name with -",
+			input:    "progress rollout test-name",
+			found:    false,
+			expected: "test-name",
+		},
+		{
+			name:     "Config name with - .",
+			input:    "progress rollout test-.name",
+			found:    false,
+			expected: "test-.name",
+		},
+		{
+			name:     "Config name with .",
+			input:    "progress rollout test.name",
+			found:    false,
+			expected: "test.name",
+		},
+		{
+			name:     "Config name with _",
+			input:    "progress rollout test_name",
+			found:    false,
+			expected: "test_name",
+		},
 	}
 
 	for _, tc := range cases {

--- a/cmd/action/main_test.go
+++ b/cmd/action/main_test.go
@@ -73,6 +73,12 @@ func Test_extractName(t *testing.T) {
 			found:    true,
 			expected: "test_name",
 		},
+		{
+			name:     "Readme example",
+			input:    "Trigger rollout for dev: progress rollout dev-config",
+			found:    true,
+			expected: "dev-config",
+		},
 	}
 
 	for _, tc := range cases {

--- a/cmd/action/main_test.go
+++ b/cmd/action/main_test.go
@@ -52,25 +52,25 @@ func Test_extractName(t *testing.T) {
 		{
 			name:     "Config name with -",
 			input:    "progress rollout test-name",
-			found:    false,
+			found:    true,
 			expected: "test-name",
 		},
 		{
 			name:     "Config name with - .",
 			input:    "progress rollout test-.name",
-			found:    false,
+			found:    true,
 			expected: "test-.name",
 		},
 		{
 			name:     "Config name with .",
 			input:    "progress rollout test.name",
-			found:    false,
+			found:    true,
 			expected: "test.name",
 		},
 		{
 			name:     "Config name with _",
 			input:    "progress rollout test_name",
-			found:    false,
+			found:    true,
 			expected: "test_name",
 		},
 	}

--- a/cmd/action/main_test.go
+++ b/cmd/action/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_extractName(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		found    bool
+		expected string
+	}{
+		{
+			name:     "no name",
+			input:    "progress rollout",
+			found:    false,
+			expected: "",
+		},
+		{
+			name:     "name",
+			input:    "progress rollout test",
+			found:    true,
+			expected: "test",
+		},
+		{
+			name:     "name with prefix and trailing space",
+			input:    "this is a commit message progress rollout test  ",
+			found:    true,
+			expected: "test",
+		},
+		{
+			name:     "name with prefix and leading space",
+			input:    "  progress rollout test",
+			found:    true,
+			expected: "test",
+		},
+		{
+			name:     "name with prefix and leading and trailing space",
+			input:    "  this is a commit message   progress rollout test  ",
+			found:    true,
+			expected: "test",
+		},
+		{
+			name:     "invalid suffix",
+			input:    "progress rollout test test",
+			found:    false,
+			expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			name, found := extractConfigName(tc.input)
+			require.Equal(t, tc.found, found)
+			require.Equal(t, tc.expected, name)
+		})
+	}
+
+}

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -1,0 +1,48 @@
+package repo
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// CloneRepo clones a repository from the provided URL and branch. If the cloneURL
+// is empty, the function will attempt to clone the repository using a GitHub
+// URL assembled from the GITHUB_ACTOR, GITHUB_REPOSITORY environment variables,
+// and the provided token.
+func CloneRepo(cloneURL, branch, token string) (*git.Repository, error) {
+	// TODO(jsirianni): githubURL should be assembled outside of this package
+	// and passed in. We could remove the need for token, actor, and repo.
+
+	githubActor := os.Getenv("GITHUB_ACTOR")
+	githubRepo := os.Getenv("GITHUB_REPOSITORY")
+	if cloneURL == "" {
+		cloneURL = fmt.Sprintf(
+			"https://%s:%s@github.com/%s.git",
+			githubActor,
+			token,
+			githubRepo,
+		)
+	}
+
+	// TODO(jsirianni): This context sets the clone timeout. This should be
+	// a configurable option.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*120)
+	defer cancel()
+
+	repo, err := git.PlainCloneContext(ctx, "./out_repo", false, &git.CloneOptions{
+		URL:           cloneURL,
+		Progress:      os.Stdout,
+		SingleBranch:  true,
+		ReferenceName: plumbing.NewBranchReferenceName(branch),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("clone repository: %w", err)
+	}
+
+	return repo, nil
+}


### PR DESCRIPTION
This PR implements support for [Progressive Rollouts](https://observiq.com/docs/feature-guides/progressive-rollouts).

The action will check if the head commit matches the following regex:
```
progress rollout (\S+)$
```

Commit messages can look like this:
- `This is a commit progress rollout my-config`
- `progress rollout my-config`

This allows the user to include context. the `progress rollout <name>` piece must be at the end of the commit message.

If the head commit does not contain the `progress rollout` message, the normal workflow will execute.