### PR TITLE
Run rollout if github_url is set

### DIFF
--- a/cmd/action/main.go
+++ b/cmd/action/main.go
@@ -125,7 +125,7 @@ func main() {
 		zap.Any("bindplane_version", version.Tag),
 	)
 
-	if token != "" {
+	if token != "" || github_url != "" {
 		// Retrieve the commit message from the head commit on the branch
 		message, err := commitMessage(github_url, branch, token)
 		if err != nil {


### PR DESCRIPTION
Its possible token is set in the URL without specifying token itself. In either case, we want to clone the repo.