### PR TITLE
feat: Support Connectors and Fleets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,19 +68,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # This matrix allows us to test multiple bindplane versions.
-        # When writing back to the repo, we write to directories based
-        # on the bindplane version.
-        bindplane_versions:
-          - 1.55.0 # keep
-          - 1.59.0 # organizations and projects
-          - 1.65.0
-          - 1.73.0
-          - 1.80.0
-          - 1.86.0
-          - 1.89.3
-          - 1.96.0
-          - latest # keep
+        # This matrix allows us to test multiple bindplane versions with the
+        # correct set of resources. Connectors and fleets are only applied and
+        # queried when the version supports them.
+        include:
+          - bindplane_versions: 1.55.0
+            support_connectors: false
+            support_fleets: false
+          - bindplane_versions: 1.59.0
+            support_connectors: false
+            support_fleets: false
+          - bindplane_versions: 1.83.0
+            support_connectors: true
+            support_fleets: false
+          - bindplane_versions: 1.91.0
+            support_connectors: true
+            support_fleets: true
+          - bindplane_versions: 1.96.0
+            support_connectors: true
+            support_fleets: true
+          - bindplane_versions: latest
+            support_connectors: true
+            support_fleets: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -199,8 +208,8 @@ jobs:
           bindplane_username: admin
           bindplane_password: admin
           destination_path: test/resources/destinations/resource.yaml
-          connector_path: test/resources/connectors/resource.yaml
-          fleet_path: test/resources/fleets/resource.yaml
+          connector_path: ${{ matrix.support_connectors && 'test/resources/connectors/resource.yaml' || '' }}
+          fleet_path: ${{ matrix.support_fleets && 'test/resources/fleets/resource.yaml' || '' }}
           configuration_path: test/resources/configurations/resource.yaml
           configuration_output_dir: test/otel/${{ matrix.bindplane_versions }}
           configuration_output_branch: otel-raw-configs
@@ -224,8 +233,8 @@ jobs:
           bindplane_password: admin
           # This is a directory
           processor_path: test/resources/processors
-          connector_path: test/resources/connectors
-          fleet_path: test/resources/fleets
+          connector_path: ${{ matrix.support_connectors && 'test/resources/connectors' || '' }}
+          fleet_path: ${{ matrix.support_fleets && 'test/resources/fleets' || '' }}
           # Should detect the resource in destinations/ and the
           # two resources in the 'multi' sub directory
           destination_path: test/resources/destinations
@@ -233,12 +242,20 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tls_ca_cert: ${{ env.TLS_CA_CERT }}
 
-      - name: Get Resources
+      - name: Get Destinations and Configurations
         if: always()
         run: |
           docker exec bindplane /bindplane get destinations --tls-ca /ca.crt
           docker exec bindplane /bindplane get configurations --tls-ca /ca.crt
+
+      - name: Get Connectors
+        if: always() && matrix.support_connectors
+        run: |
           docker exec bindplane /bindplane get connector --tls-ca /ca.crt
+
+      - name: Get Fleets
+        if: always() && matrix.support_fleets
+        run: |
           docker exec bindplane /bindplane get fleet --tls-ca /ca.crt
 
       - name: Debug Container Logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,8 @@ jobs:
           bindplane_username: admin
           bindplane_password: admin
           destination_path: test/resources/destinations/resource.yaml
+          connector_path: test/resources/connectors/resource.yaml
+          fleet_path: test/resources/fleets/resource.yaml
           configuration_path: test/resources/configurations/resource.yaml
           configuration_output_dir: test/otel/${{ matrix.bindplane_versions }}
           configuration_output_branch: otel-raw-configs
@@ -222,6 +224,8 @@ jobs:
           bindplane_password: admin
           # This is a directory
           processor_path: test/resources/processors
+          connector_path: test/resources/connectors
+          fleet_path: test/resources/fleets
           # Should detect the resource in destinations/ and the
           # two resources in the 'multi' sub directory
           destination_path: test/resources/destinations
@@ -234,6 +238,8 @@ jobs:
         run: |
           docker exec bindplane /bindplane get destinations --tls-ca /ca.crt
           docker exec bindplane /bindplane get configurations --tls-ca /ca.crt
+          docker exec bindplane /bindplane get connector --tls-ca /ca.crt
+          docker exec bindplane /bindplane get fleet --tls-ca /ca.crt
 
       - name: Debug Container Logs
         if: always()

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Bindplane requires a license. You can request a free license [here](https://obse
 | destination_path              |          | Path to the file or directory which contains the Bindplane destination resources                                                                                                                                                                      |
 | source_path                   |          | Path to the file or directory which contains the Bindplane source resources                                                                                                                                                                           |
 | processor_path                |          | Path to the file or directory which contains the Bindplane processor resources                                                                                                                                                                        |
+| connector_path                |          | Path to the file or directory which contains the Bindplane connector resources                                                                                                                                                                        |
+| fleet_path                    |          | Path to the file or directory which contains the Bindplane fleet resources                                                                                                                                                                             |
 | configuration_path            |          | Path to the file or directory which contains the Bindplane configuration resources                                                                                                                                                                    |
 | enable_otel_config_write_back | `false`  | Whether or not the action should write the raw OpenTelemetry configurations back to the repository.                                                                                                                                      |
 | configuration_output_dir      |          | When write back is enabled, this is the path that will be written to.                                                                                                                                                                    |
@@ -42,6 +44,8 @@ the `bindplane get` commands with the `--export` flag.
 bindplane get destination -o yaml --export > destination.yaml
 bindplane get source -o yaml --export > source.yaml
 bindplane get processor -o yaml --export > processor.yaml
+bindplane get connector -o yaml --export > connector.yaml
+bindplane get fleet -o yaml --export > fleet.yaml
 bindplane get configuration -o yaml --export > configuration.yaml
 ```
 
@@ -89,6 +93,8 @@ jobs:
           bindplane_password: ${{ secrets.BINDPLANE_PASSWORD }}
           target_branch: main
           destination_path: destination.yaml
+          connector_path: connector.yaml
+          fleet_path: fleet.yaml
           configuration_path: configuration.yaml
           enable_otel_config_write_back: true
           configuration_output_dir: otel/
@@ -125,6 +131,8 @@ using a TLS endpoint (`https`).
     bindplane_password: ${{ secrets.BINDPLANE_PASSWORD }}
     target_branch: main
     destination_path: destination.yaml
+    connector_path: connector.yaml
+    fleet_path: fleet.yaml
     configuration_path: configuration.yaml
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'Path to the file or directory which contains the Bindplane source resources'
   processor_path:
     description: 'Path to the file or directory which contains the Bindplane processor resources'
+  connector_path:
+    description: 'Path to the file or directory which contains the Bindplane connector resources'
+  fleet_path:
+    description: 'Path to the file or directory which contains the Bindplane fleet resources'
   configuration_path:
     description: 'Path to the file or directory which contains the Bindplane configuration resources'
   enable_otel_config_write_back:
@@ -62,5 +66,7 @@ runs:
     - ${{ inputs.tls_ca_cert }}
     - ${{ inputs.source_path }}
     - ${{ inputs.processor_path }}
+    - ${{ inputs.connector_path }}
+    - ${{ inputs.fleet_path }}
     - ${{ inputs.github_url }}
     - ${{ inputs.user_agent }}

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -312,6 +312,56 @@ func TestWithConfigurationPath(t *testing.T) {
 	}
 }
 
+func TestWithConnectorPath(t *testing.T) {
+	cases := []struct {
+		name   string
+		intput string
+		expect *Action
+	}{
+		{
+			"Set connector path",
+			"/tmp",
+			&Action{
+				connectorPath: "/tmp",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Action{}
+			opt := WithConnectorPath(tc.intput)
+			opt(a)
+			require.Equal(t, tc.expect, a)
+		})
+	}
+}
+
+func TestWithFleetPath(t *testing.T) {
+	cases := []struct {
+		name   string
+		intput string
+		expect *Action
+	}{
+		{
+			"Set fleet path",
+			"/tmp",
+			&Action{
+				fleetPath: "/tmp",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Action{}
+			opt := WithFleetPath(tc.intput)
+			opt(a)
+			require.Equal(t, tc.expect, a)
+		})
+	}
+}
+
 func TestWithEnableAutoRollout(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/cmd/action/args.go
+++ b/cmd/action/args.go
@@ -18,7 +18,7 @@ func parseArgs() error {
 	// Add one to account for arg 0 being the binary name
 	count := argCount + 1
 	if len(args) != count {
-		return fmt.Errorf("Not enough arguments, expected 18, got %d. %s.", len(args), action.BugError)
+		return fmt.Errorf("Not enough arguments, expected 20, got %d. %s.", len(args), action.BugError)
 	}
 
 	// First arg is always the binary name, so we skip it. We could
@@ -63,8 +63,10 @@ func parseArgs() error {
 
 	source_path = args[14]
 	processor_path = args[15]
-	github_url = args[16]
-	user_agent = args[17]
+	connector_path = args[16]
+	fleet_path = args[17]
+	github_url = args[18]
+	user_agent = args[19]
 
 	return nil
 }

--- a/cmd/action/main.go
+++ b/cmd/action/main.go
@@ -16,7 +16,7 @@ import (
 // include the binary name itself (which is returned by os.Args[0]).
 // When adding new arguments to the action, this number should be updated
 // and new global variables should be declared and handled in parseArgs().
-const argCount = 17
+const argCount = 19
 
 // Global variables will be used when creating the action configuration. These
 // are the options set by the user. Their order in parseArgs() is important.
@@ -36,6 +36,8 @@ var (
 	tls_ca_cert                   string
 	source_path                   string
 	processor_path                string
+	connector_path                string
+	fleet_path                    string
 	github_url                    string
 	user_agent                    string
 )
@@ -108,6 +110,8 @@ func main() {
 		action.WithDestinationPath(destination_path),
 		action.WithSourcePath(source_path),
 		action.WithProcessorPath(processor_path),
+		action.WithConnectorPath(connector_path),
+		action.WithFleetPath(fleet_path),
 		action.WithConfigurationPath(configuration_path),
 
 		// Auto rollout option(s)

--- a/cmd/action/validate.go
+++ b/cmd/action/validate.go
@@ -130,7 +130,9 @@ func validateFilePaths() error {
 		model.KindDestination:   destination_path,
 		model.KindSource:        source_path,
 		model.KindProcessor:     processor_path,
+		model.KindConnector:     connector_path,
 		model.KindConfiguration: configuration_path,
+		model.KindFleet:         fleet_path,
 	}
 
 	for kind, path := range files {

--- a/internal/client/model/kind.go
+++ b/internal/client/model/kind.go
@@ -7,4 +7,6 @@ const (
 	KindSource        Kind = "Source"
 	KindProcessor     Kind = "Processor"
 	KindDestination   Kind = "Destination"
+	KindConnector     Kind = "Connector"
+	KindFleet         Kind = "Fleet"
 )

--- a/test/resources/connectors/resource.yaml
+++ b/test/resources/connectors/resource.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: bindplane.observiq.com/v1
+kind: Connector
+metadata:
+    name: test-routing-connector
+spec:
+    type: routing
+    parameters: []
+---
+apiVersion: bindplane.observiq.com/v1
+kind: Connector
+metadata:
+    name: test-connector
+spec:
+    type: routing
+    parameters: []

--- a/test/resources/fleets/resource.yaml
+++ b/test/resources/fleets/resource.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: bindplane.observiq.com/v1
+kind: Fleet
+metadata:
+    name: test-fleet
+spec:
+    selector:
+        matchLabels: {}
+---
+apiVersion: bindplane.observiq.com/v1
+kind: Fleet
+metadata:
+    name: ci-fleet
+spec:
+    selector:
+        matchLabels: {}


### PR DESCRIPTION
This PR adds support for Connectors and Fleets. Under the hood, the action relies on the Bindplane `/v1/apply` endpoint, which already accepts resources of any type.

The action exposes two new options: `connector_path` and `fleet_path`. This is a logical organizational structure that can be extended later if we need to perform validation or additional work with a given resource type.

Test resources are included, and the CI test action is updated to include the two new params.